### PR TITLE
made changes to align schema and typedefs

### DIFF
--- a/server/models/Card.js
+++ b/server/models/Card.js
@@ -15,7 +15,7 @@ const cardSchema = new Schema({
     required: true,
   },
   position: {
-    type: Int,
+    type: Number, // Mongoose type for numbers, graphql will understand this as Int, Int does not exist  in mongoose 
     required: true,
   },
 });

--- a/server/schemas/typeDefs.js
+++ b/server/schemas/typeDefs.js
@@ -16,6 +16,7 @@ type Board {
     title: String!
     description: String
     user: User! 
+    columns: [Column] # Reflecting the virtual field
 
 }
 
@@ -23,6 +24,7 @@ type Column {
     _id: ID!
     title: String!
     board: Board!
+    cards: [Card] # Reflecting the virtual field
 }
 
 type Card {


### PR DESCRIPTION
Ensured that the Mongoose schemas and GraphQL type definitions align, but do not directly translate Number in Mongoose to anything other than Int in graphql 